### PR TITLE
console: make W and w 512 wide

### DIFF
--- a/src/Sporniket-Nostalgie2-Console.sfdir/_W.glyph
+++ b/src/Sporniket-Nostalgie2-Console.sfdir/_W.glyph
@@ -1,6 +1,6 @@
 StartChar: W
 Encoding: 87 87 53
-Width: 510
+Width: 512
 VWidth: 0
 InSpiro: 1
 Flags: MW

--- a/src/Sporniket-Nostalgie2-Console.sfdir/w.glyph
+++ b/src/Sporniket-Nostalgie2-Console.sfdir/w.glyph
@@ -1,6 +1,6 @@
 StartChar: w
 Encoding: 119 119 23
-Width: 510
+Width: 512
 VWidth: 0
 InSpiro: 1
 Flags: MW


### PR DESCRIPTION
Every other glyph is 512, so a 510 advance broke strict monospacing.